### PR TITLE
Fix path class ambiguity with GCC compiler

### DIFF
--- a/xo/diagnose/profiler_config.h
+++ b/xo/diagnose/profiler_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "xo/system/log_level.h"
+#include "xo/container/prop_node.h"
 
 #ifdef XO_ENABLE_PROFILER
 #	include "xo/diagnose/profiler.h"

--- a/xo/filesystem/path.cpp
+++ b/xo/filesystem/path.cpp
@@ -1,7 +1,5 @@
 #include "path.h"
 
-#include <filesystem>
-
 namespace xo
 {
 	const size_t path::npos = string::npos;

--- a/xo/filesystem/path.h
+++ b/xo/filesystem/path.h
@@ -4,11 +4,7 @@
 #include "xo/string/string_type.h"
 #include "xo/string/string_cast.h"
 
-namespace std {
-	namespace filesystem {
-		class path;
-	}
-}
+#include <filesystem>
 
 namespace xo
 {


### PR DESCRIPTION
From #6, the screenshot showed that there were problems compiling `path.cpp` with GCC due to `path` being ambiguous in `<filesystem>`. I tested that this may be the case by changing the include order in `path.cpp`:

From:
```
#include "path.h"
#include <filesystem>
```

To:
```
#include <filesystem>
#include "path.h"
```
This fixed the ambiguity, but seemed fragile. So, I moved `#include <filesystem>` into `path.h` instead.

This led to one more compiler issue as seen here:
![image](https://user-images.githubusercontent.com/7455790/57033673-6151dc80-6c02-11e9-899d-3958f5348665.png)
Removing the following from `path.h` fixed the problem, but feedback on this would be great because I'm not 100% sure that this won't cause problems down the road.:
```
namespace std {
	namespace filesystem {
		class path;
	}
}
```