### PR TITLE
bug fix in catmull spline and for compiling frange.h in VS2017

### DIFF
--- a/xo/geometry/catmull_rom.h
+++ b/xo/geometry/catmull_rom.h
@@ -70,16 +70,21 @@ namespace xo
 		{
 			xo_assert( points.size() >= 4 && times.size() == ( points.size() - 2 ) );
 			segments_.reserve( points.size() - 4 );
-			for ( size_t i = 0; i <= points.size() - 4 )
+			for ( size_t i = 0; i <= points.size() - 4; ++i)
 				segments_.emplace_back( points[ i ], points[ i + 1 ], points[ i + 2 ], points[ i + 3 ] );
 		}
 
 		P operator()( T t ) {
+			//assume times_ is sorted
 			auto it = std::lower_bound( times_.begin(), times_.end(), t );
-			if ( it == times_.end() ) it = times_.begin();
-			if ( it == times_.end() - 1 ) it = times_.end() - 2;
-			size_t index = it - times_.begin();
-			return segments_[ index ]( ( t - *it ) / ( *( it + 1 ) - *it ) );
+			if (it == times_.end()) {//no time is larger than t, outside the range
+				//it = times_.begin();
+				it = times_.end() - 1;
+			}
+			//if ( it == times_.end() - 1 ) it = times_.end() - 2;
+			if (it == times_.begin()) it = times_.begin() + 1;
+			size_t index = it - times_.begin() -1; //it could be begin()
+			return segments_[ index ]( ( t - *(it-1) ) / ( *it  - *(it-1) ) );
 		}
 
 	private:

--- a/xo/utility/frange.h
+++ b/xo/utility/frange.h
@@ -31,7 +31,7 @@ namespace xo
 			T operator++( int ) { step_ += T( 1 ); return max_step_ - T( 1 ); }
 			bool operator==( const iterator& other ) { return other.step_ == step_; }
 			bool operator!=( const iterator& other ) { return other.step_ != step_; }
-			T operator*() { return min_ + step_ * ( max_ - min_ ) / max_step_; }
+			T operator*() const { return min_ + step_ * ( max_ - min_ ) / max_step_; }
 		};
 
 		iterator begin() const { return iterator( T( 0 ), min_, max_, max_step_ ); }


### PR DESCRIPTION
In frange.h, add a const to function T operator*()  in order to make it compile in VS2017.
Bug fixes in catmull_rom spline.