### PR TITLE
Fixed thread priority not returning anything when compiling in with n…

### DIFF
--- a/xo/thread/thread_priority.cpp
+++ b/xo/thread/thread_priority.cpp
@@ -84,6 +84,8 @@ namespace xo
 		result.pc_ = ::GetPriorityClass( h );
 		result.tp_= ::GetThreadPriority( h );
 		return result;
+#else
+                return {};
 #endif
 	}
 }


### PR DESCRIPTION
…on-MSVC compilers

Pops up as a warning when compiling with g++