### PR TITLE
Downgrade to CMake 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(xo)
 

--- a/xo/CMakeLists.txt
+++ b/xo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 SET (XO_LIB_NAMES
 	container


### PR DESCRIPTION
For compatibility with Ubuntu18.04 which uses CMake 3.10 as its default version.